### PR TITLE
Add toy MPP‑SPP optimization demo

### DIFF
--- a/benchmark/toy_instance.json
+++ b/benchmark/toy_instance.json
@@ -1,0 +1,16 @@
+{
+  "ports": 3,
+  "bays": [
+    {"id": 1, "capacity_teu": 50, "capacity_weight": 100},
+    {"id": 2, "capacity_teu": 50, "capacity_weight": 100},
+    {"id": 3, "capacity_teu": 50, "capacity_weight": 100}
+  ],
+  "containers": [
+    {"id": 1, "pol": 1, "pod": 3, "teu": 1, "weight": 10, "revenue": 100},
+    {"id": 2, "pol": 1, "pod": 2, "teu": 1, "weight": 12, "revenue": 120},
+    {"id": 3, "pol": 1, "pod": 3, "teu": 2, "weight": 18, "revenue": 150},
+    {"id": 4, "pol": 2, "pod": 3, "teu": 1, "weight": 8, "revenue": 90},
+    {"id": 5, "pol": 1, "pod": 2, "teu": 2, "weight": 20, "revenue": 160}
+  ],
+  "slots_per_bay": 25
+}

--- a/bridge_mpp_spp.py
+++ b/bridge_mpp_spp.py
@@ -1,0 +1,20 @@
+import json
+from typing import Dict, List
+
+import mpp_solver
+from mpp_solver import Container, Bay, MPPResult
+
+
+def bridge_to_spp(res: MPPResult, containers: List[Container], bays: List[Bay]) -> Dict[int, List[int]]:
+    """Create SPP input from MPP result."""
+    mapping: Dict[int, List[int]] = {b.id: [] for b in bays}
+    for c in containers:
+        b_id = res.assignment[c.id]
+        mapping[b_id].append(c.id)
+    return mapping
+
+if __name__ == "__main__":
+    bays, containers = mpp_solver.load_instance("benchmark/toy_instance.json")
+    res = mpp_solver.solve_mpp(bays, containers)
+    mapping = bridge_to_spp(res, containers, bays)
+    print(json.dumps(mapping, indent=2))

--- a/mpp_solver.py
+++ b/mpp_solver.py
@@ -1,0 +1,53 @@
+import pulp as pl
+import json
+from dataclasses import dataclass
+from typing import List, Dict
+
+@dataclass
+class Container:
+    id: int
+    pol: int
+    pod: int
+    teu: int
+    weight: float
+    revenue: float
+
+@dataclass
+class Bay:
+    id: int
+    capacity_teu: int
+    capacity_weight: float
+
+@dataclass
+class MPPResult:
+    assignment: Dict[int, int]  # container_id -> bay_id
+    objective: float
+
+
+def load_instance(path: str):
+    with open(path) as f:
+        data = json.load(f)
+    bays = [Bay(**b) for b in data["bays"]]
+    containers = [Container(**c) for c in data["containers"]]
+    return bays, containers
+
+
+def solve_mpp(bays: List[Bay], containers: List[Container]) -> MPPResult:
+    prob = pl.LpProblem("mpp", pl.LpMaximize)
+    x = pl.LpVariable.dicts("x", ((c.id, b.id) for c in containers for b in bays), 0, 1, pl.LpBinary)
+    # Each container assigned once
+    for c in containers:
+        prob += pl.lpSum(x[(c.id, b.id)] for b in bays) == 1
+    # Capacity
+    for b in bays:
+        prob += pl.lpSum(c.teu * x[(c.id, b.id)] for c in containers) <= b.capacity_teu
+        prob += pl.lpSum(c.weight * x[(c.id, b.id)] for c in containers) <= b.capacity_weight
+    prob += pl.lpSum(c.revenue * x[(c.id, b.id)] for c in containers for b in bays)
+    prob.solve(pl.PULP_CBC_CMD(msg=False))
+    assignment = {c.id: next(b.id for b in bays if pl.value(x[(c.id, b.id)]) > 0.5) for c in containers}
+    return MPPResult(assignment, pl.value(prob.objective))
+
+if __name__ == "__main__":
+    bays, containers = load_instance("benchmark/toy_instance.json")
+    res = solve_mpp(bays, containers)
+    print(json.dumps({"assignment": res.assignment, "obj": res.objective}, indent=2))

--- a/optimize.py
+++ b/optimize.py
@@ -1,0 +1,22 @@
+import json
+import mpp_solver
+from bridge_mpp_spp import bridge_to_spp
+import spp_solver
+
+
+def main():
+    bays, containers = mpp_solver.load_instance("benchmark/toy_instance.json")
+    mpp_res = mpp_solver.solve_mpp(bays, containers)
+    mapping = bridge_to_spp(mpp_res, containers, bays)
+    spp_res = spp_solver.solve_spp(mapping, containers, bays, slots_per_bay=25)
+    result = {
+        "mpp_objective": mpp_res.objective,
+        "spp_objective": spp_res.objective,
+        "mpp_assignment": mpp_res.assignment,
+        "spp_assignment": spp_res.assignment,
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/spp_solver.py
+++ b/spp_solver.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from typing import Dict, List
+import pulp as pl
+
+from mpp_solver import Container, Bay
+import mpp_solver
+
+@dataclass
+class SPPSolution:
+    assignment: Dict[int, Dict[int, int]]
+    objective: float
+
+
+def solve_spp(mapping: Dict[int, List[int]], containers: List[Container], bays: List[Bay], slots_per_bay: int) -> SPPSolution:
+    prob = pl.LpProblem("spp", pl.LpMaximize)
+    cont_lookup = {c.id: c for c in containers}
+    y = pl.LpVariable.dicts("y", ((b.id, s, c_id) for b in bays for s in range(slots_per_bay) for c_id in mapping[b.id]), 0, 1, pl.LpBinary)
+    for b in bays:
+        for s in range(slots_per_bay):
+            prob += pl.lpSum(y[(b.id, s, c_id)] for c_id in mapping[b.id]) <= 1
+    for b in bays:
+        for c_id in mapping[b.id]:
+            prob += pl.lpSum(y[(b.id, s, c_id)] for s in range(slots_per_bay)) == 1
+    for b in bays:
+        prob += pl.lpSum(cont_lookup[c_id].teu * y[(b.id, s, c_id)] for c_id in mapping[b.id] for s in range(slots_per_bay)) <= b.capacity_teu
+        prob += pl.lpSum(cont_lookup[c_id].weight * y[(b.id, s, c_id)] for c_id in mapping[b.id] for s in range(slots_per_bay)) <= b.capacity_weight
+    prob += pl.lpSum(cont_lookup[c_id].revenue * y[(b.id, s, c_id)] for b in bays for s in range(slots_per_bay) for c_id in mapping[b.id])
+    prob.solve(pl.PULP_CBC_CMD(msg=False))
+    assignment: Dict[int, Dict[int, int]] = {b.id: {} for b in bays}
+    for b in bays:
+        for s in range(slots_per_bay):
+            for c_id in mapping[b.id]:
+                if pl.value(y[(b.id, s, c_id)]) > 0.5:
+                    assignment[b.id][s] = c_id
+    return SPPSolution(assignment, pl.value(prob.objective))
+
+if __name__ == "__main__":
+    from bridge_mpp_spp import bridge_to_spp
+    bays, containers = mpp_solver.load_instance("benchmark/toy_instance.json")
+    mpp_res = mpp_solver.solve_mpp(bays, containers)
+    mapping = bridge_to_spp(mpp_res, containers, bays)
+    res = solve_spp(mapping, containers, bays, slots_per_bay=25)
+    print(res.assignment)


### PR DESCRIPTION
## Summary
- add a toy benchmark instance
- implement a basic MPP solver with PuLP
- create a bridge to generate SPP input
- implement a PuLP-based SPP solver
- provide `optimize.py` to run MPP then SPP on the toy instance

## Testing
- `python optimize.py`

------
https://chatgpt.com/codex/tasks/task_e_68885079e1b8832f9c44e406179fd39f